### PR TITLE
feat: add key-value settings API endpoints

### DIFF
--- a/dashboard/src/app/api/settings/[key]/route.ts
+++ b/dashboard/src/app/api/settings/[key]/route.ts
@@ -1,0 +1,74 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getDb, schema } from "@/lib/db";
+import { eq } from "drizzle-orm";
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: { key: string } }
+) {
+  try {
+    const key = params.key;
+    const db = getDb();
+    const setting = await db.select().from(schema.settings).where(eq(schema.settings.key, key)).get();
+
+    if (!setting) {
+      return NextResponse.json({ error: "Setting not found" }, { status: 404 });
+    }
+
+    return NextResponse.json({ key: setting.key, value: setting.value });
+  } catch (error) {
+    console.error("[/api/settings/[key] GET] Error:", error);
+    return NextResponse.json({ error: "Failed to get setting" }, { status: 500 });
+  }
+}
+
+export async function PUT(
+  request: NextRequest,
+  { params }: { params: { key: string } }
+) {
+  try {
+    const key = params.key;
+    const body = await request.json();
+    const { value } = body;
+
+    if (value === undefined) {
+      return NextResponse.json({ error: "value is required" }, { status: 400 });
+    }
+
+    const db = getDb();
+    const existing = await db.select().from(schema.settings).where(eq(schema.settings.key, key)).get();
+
+    if (existing) {
+      await db
+        .update(schema.settings)
+        .set({ value: String(value), updatedAt: new Date() })
+        .where(eq(schema.settings.key, key));
+    } else {
+      await db.insert(schema.settings).values({
+        key,
+        value: String(value),
+        updatedAt: new Date(),
+      });
+    }
+
+    return NextResponse.json({ success: true });
+  } catch (error) {
+    console.error("[/api/settings/[key] PUT] Error:", error);
+    return NextResponse.json({ error: "Failed to save setting" }, { status: 500 });
+  }
+}
+
+export async function DELETE(
+  request: NextRequest,
+  { params }: { params: { key: string } }
+) {
+  try {
+    const key = params.key;
+    const db = getDb();
+    await db.delete(schema.settings).where(eq(schema.settings.key, key));
+    return NextResponse.json({ success: true });
+  } catch (error) {
+    console.error("[/api/settings/[key] DELETE] Error:", error);
+    return NextResponse.json({ error: "Failed to delete setting" }, { status: 500 });
+  }
+}

--- a/dashboard/src/app/api/settings/route.ts
+++ b/dashboard/src/app/api/settings/route.ts
@@ -1,0 +1,50 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getDb, schema } from "@/lib/db";
+import { eq } from "drizzle-orm";
+
+export async function GET() {
+  try {
+    const db = getDb();
+    const allSettings = await db.select().from(schema.settings);
+    const settings: Record<string, string> = {};
+    for (const s of allSettings) {
+      settings[s.key] = s.value;
+    }
+    return NextResponse.json({ settings });
+  } catch (error) {
+    console.error("[/api/settings GET] Error:", error);
+    return NextResponse.json({ error: "Failed to get settings" }, { status: 500 });
+  }
+}
+
+export async function PUT(request: NextRequest) {
+  try {
+    const body = await request.json();
+    const { key, value } = body;
+
+    if (!key || value === undefined) {
+      return NextResponse.json({ error: "key and value are required" }, { status: 400 });
+    }
+
+    const db = getDb();
+    const existing = await db.select().from(schema.settings).where(eq(schema.settings.key, key)).get();
+
+    if (existing) {
+      await db
+        .update(schema.settings)
+        .set({ value: String(value), updatedAt: new Date() })
+        .where(eq(schema.settings.key, key));
+    } else {
+      await db.insert(schema.settings).values({
+        key,
+        value: String(value),
+        updatedAt: new Date(),
+      });
+    }
+
+    return NextResponse.json({ success: true });
+  } catch (error) {
+    console.error("[/api/settings PUT] Error:", error);
+    return NextResponse.json({ error: "Failed to save setting" }, { status: 500 });
+  }
+}


### PR DESCRIPTION
## Summary
- Add generic key-value settings API using existing SQLite settings table
- GET /api/settings - Get all settings
- PUT /api/settings - Set a setting value
- GET /api/settings/[key] - Get specific setting
- PUT /api/settings/[key] - Set specific setting value
- DELETE /api/settings/[key] - Delete a setting

Closes #24